### PR TITLE
Improve Lighthouse SEO and A11y Rating

### DIFF
--- a/components/atoms/Logo.vue
+++ b/components/atoms/Logo.vue
@@ -4,7 +4,13 @@
     class="flex items-center font-bold text-black"
     :class="`text-${textSize}`"
   >
-    <img :src="skLogoWhite" class="mr-3" :class="`w-${size}`" /> Stormkit
+    <img
+      :src="skLogoWhite"
+      class="mr-3"
+      :class="`w-${size}`"
+      alt="Stormkit Logo"
+    />
+    Stormkit
     <slot></slot>
   </nuxt-link>
 </template>

--- a/components/atoms/Modal.vue
+++ b/components/atoms/Modal.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="isOpen || isClosing"
+    aria-label="Close the modal"
     class="modal-overlay fixed inset-0 flex justify-center z-50 md:p-6 bg-transparent-30"
     role="button"
     :class="overlayClasses"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,6 +5,9 @@ module.exports = {
    */
   head: {
     title: 'Stormkit - Serverless infrastructure for javascript applications',
+    htmlAttrs: {
+      lang: 'en'
+    },
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },

--- a/pages/-index-supported-techs.vue
+++ b/pages/-index-supported-techs.vue
@@ -16,7 +16,7 @@
         :style="`animation-delay: ${i * 0.5}s`"
         class="bounce inline-flex items-center justify-center bg-white rounded-full w-20 h-20 shadow border-t border-gray-80 mr-4"
       >
-        <img :src="image" class="w-10" />
+        <img :src="image.src" :alt="image.alt" class="w-10" />
       </span>
     </div>
     <div class="text-center mt-12">
@@ -48,15 +48,15 @@ export default {
   data() {
     return {
       images: [
-        pngAngular,
-        pngHtml5,
-        pngJs,
-        pngNodeJs,
-        pngNextJs,
-        pngNuxtJs,
-        pngReact,
-        pngVue,
-        pngSvelte
+        { src: pngAngular, alt: 'Angular' },
+        { src: pngHtml5, alt: 'HTML 5' },
+        { src: pngJs, alt: 'JavaScript' },
+        { src: pngNodeJs, alt: 'Node.js' },
+        { src: pngNextJs, alt: 'Next.js' },
+        { src: pngNuxtJs, alt: 'Nuxt.js' },
+        { src: pngReact, alt: 'React' },
+        { src: pngVue, alt: 'Vue' },
+        { src: pngSvelte, alt: 'Svelte' }
       ]
     }
   }

--- a/pages/-index-testimonials.vue
+++ b/pages/-index-testimonials.vue
@@ -10,8 +10,8 @@
       <div class="flex flex-col md:flex-row md:justify-between">
         <sk-card
           v-for="testimonial in testimonials"
-          :key="testimonial.user"
-          :image="{ src: testimonial.image, alt: testimonial.user }"
+          :key="testimonial.name"
+          :image="{ src: testimonial.image, alt: testimonial.name }"
           class="testimonial relative md:w-p-30 mb-6 md:mb-0"
         >
           <div class="p-6 card-content">
@@ -41,6 +41,7 @@
                   target="_blank"
                   rel="noopener referrer"
                 >
+                  <span class="sr-only">LinkedIn</span>
                   <sk-linkedin class="opacity-75 hover:opacity-100" />
                 </a>
               </span>

--- a/pages/-index-welcome.vue
+++ b/pages/-index-welcome.vue
@@ -47,6 +47,7 @@
         <img
           :src="versionControl"
           class="version-control flex-initial relative mt-4 md:mt-0 w-3/4 md:w-full md:max-w-lg"
+          alt="Stormkit browser illustration"
         />
         <div class="absolute left-0 right-0 bottom-0 hidden mb-12 md:block">
           <sk-mouse-scroll


### PR DESCRIPTION
This PR improves the SEO and accessibility score in the Lighthouse rating for the index page.

It mostly just adds `alt` tags to the images used on the index page but also an `aria-label` and texts only for screen readers.

The accessibility is not on 100% because your brand color/`#f6005c` doesn‘t have enough contrast with the white background:

![image](https://user-images.githubusercontent.com/28510368/96707155-ca4d8700-1397-11eb-915a-dcf5081a3f17.png)

Relates to #49. The performance on `www.stormkit.io` seems to be worse than in my test env, possibly because of tawk and GTM, or my older MacBook Air. 🤷 

## Screenshots

| | Before | After |
|---|---|---|
| **Screenshot** | ![image](https://user-images.githubusercontent.com/28510368/96705166-37135200-1395-11eb-8077-4361ffc97fd3.png)  | ![image](https://user-images.githubusercontent.com/28510368/96705398-86598280-1395-11eb-8386-2131a69ee123.png) |
| **Scores** | Performance: 29, A11y: 73, Best Pract.: 100, SEO: 89 | ∆Performance: 0, ∆A11y: +25, ∆Best Pract.: 0, ∆SEO: +11 |

Both tests were done in the dev environment, however, the performance increased to 98 when pre-building resources and serving via `yarn start. Also, the other scores did not change.

<details>
<summary>LH report with pre-built resources</summary>
<img src="https://user-images.githubusercontent.com/28510368/96705889-26afa700-1396-11eb-83e8-6555e70aae20.png" alt="lighthouse scores">
</details>