### PR TITLE
Remove unrelated note in Next.js docs

### DIFF
--- a/pages/docs/deployments/configuration/next.vue
+++ b/pages/docs/deployments/configuration/next.vue
@@ -41,11 +41,6 @@
         so we need to tell Stormkit those files directly from the CDN.
       </p>
       <pre><code>{{nextJsStormkitConfig}}</code></pre>
-      <p>
-        The <code>replace</code> is needed because Nuxt.js does not create a
-        physical <code>_nuxt</code> folder during build and we need to make our
-        CDN aware of this.
-      </p>
       <h3 class="mt-8">Method 2: Using next.config.js</h3>
       <p>
         The alternative method is to use the <code>PUBLIC_URL</code> environment


### PR DESCRIPTION
This PR remove a unrelated Nuxt.js note in Next.js configuration documentation.