### PR TITLE
Change in wording and links at the bottom of landing page

### DIFF
--- a/components/molecules/AppHeader.vue
+++ b/components/molecules/AppHeader.vue
@@ -22,6 +22,7 @@
               :key="link.path"
               :to="link.path"
               class="block text-gray-40 mb-4 px-4"
+              @click.native="toggleMenu"
             >
               {{ link.text }}
             </nuxt-link>
@@ -38,7 +39,7 @@
       <div
         class="w-full block flex-grow lg:flex lg:items-center lg:w-auto absolute md:relative inset-0 md:inset-auto hidden md:block"
       >
-        <div class="text-sm lg:flex-grow text-right text-base pr-12">
+        <div class="text-sm lg:flex-grow text-right text-sm pr-12">
           <nuxt-link
             v-for="link in links"
             :key="link.path"
@@ -70,8 +71,10 @@ export default {
   data: () => ({
     displayMobileMenu: false,
     links: [
+      { text: 'Home', path: '/' },
+      { text: 'About us', path: '/#about-us' },
+      { text: 'Partners', path: '/partners' },
       { text: 'Docs', path: '/docs' },
-      { text: 'Examples', path: '/docs/examples' },
       { text: 'Pricing', path: '/pricing' }
     ]
   }),

--- a/pages/-index-about-us.vue
+++ b/pages/-index-about-us.vue
@@ -62,7 +62,7 @@
                   navigate_next
                 </span>
                 Make building &amp; delivering applications a delightful
-                experience.
+                low-code-like experience.
               </li>
               <li class="flex items-center mb-2">
                 <span class="material-icons mr-3">
@@ -107,8 +107,9 @@
               </li>
               <li class="flex mb-4">
                 <b class="mr-4">What?</b> We automate your work infrastructure
-                and provide a kit that includes state of the art best practices
-                and features.
+                 with state of the art best practice and features.
+                 This makes Stormkit something like a low-code frontend 
+                 infrastructure service for developers.
               </li>
               <li class="flex">
                 <b class="mr-4">How?&nbsp;</b> We listen to our users.

--- a/pages/-index-about-us.vue
+++ b/pages/-index-about-us.vue
@@ -107,7 +107,7 @@
               </li>
               <li class="flex mb-4">
                 <b class="mr-4">What?</b> We automate your work infrastructure
-                 with state of the art best practice and features.
+                 with state of the art best practices and features.
                  This makes Stormkit something like a low-code frontend 
                  infrastructure service for developers.
               </li>

--- a/pages/-index-join-us.vue
+++ b/pages/-index-join-us.vue
@@ -7,21 +7,21 @@
         Join us and let's build Stormkit together
       </h2>
       <h3 class="text-sm px-3 md:px-0 text-center md:text-left mb-4 md:mb-0">
-        Oh by the way, our community is
+        Oh by the way, you can start
         <a
-          href="https://discord.gg/6yQWhyY"
+          href="https://app.stormkit.io/auth"
           target="_blank"
           rel="noopener noreferrer"
-          >chatting here</a
+          >building here</a
         >.
       </h3>
     </div>
     <sk-button
-      to="https://app.stormkit.io/auth"
+      to="https://discord.gg/6yQWhyY"
       tertiary
       class="self-center md:self-auto"
     >
-      Get started for free
+      Join our community
     </sk-button>
   </section>
 </template>


### PR DESCRIPTION
It said: "Join us and let's build Stormkit together" on the left with a button with "Get started for free" to the right. 
These are two different calls to action with two different purposes. 

My suggestion is to make it more coherent into: "Join us and let's build Stormkit together" with a link to actually join the community on Discord on the right with "Join our community".

The text below is to get them to get started for free. Happy to discuss.