### PR TITLE
fix: pricing toggle can be unselected

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -98,7 +98,7 @@ export default function Pricing() {
             value={mode}
             exclusive
             onChange={(_: any, newMode) => {
-              setMode(newMode as Mode)
+              if (newMode) setMode(newMode as Mode)
             }}
             aria-label="Platform"
           >


### PR DESCRIPTION
This fixes that the pricing toggles can be unselected.

## Screenshots

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/f7dcbeda-eaed-48bf-93cd-96f5fd2550d7 | https://github.com/user-attachments/assets/443bbb46-8baf-480c-905b-34334ddbbc0f |